### PR TITLE
Fixed non-matching environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It contains 7 demos:
 You need to set the following environment variables:
 
 - `AZURE_OPENAI_ENDPOINT`: your Azure OpenAI URL endpoint.
-- `AZURE_OPENAI_API_KEY`: your Azure OpenAI API key.
+- `AZURE_OPENAI_KEY`: your Azure OpenAI API key.
 
 ### MistralAI
 


### PR DESCRIPTION
Hi, I noticed that the README refers to the `AZURE_OPENAI_API_KEY` environment variable, but the code uses `AZURE_OPENAI_KEY`. This PR fixes that.