### PR TITLE
Update Bootstrap to 5.3.8 and fix HTML/JS issues

### DIFF
--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!answer) return;
 
     // Check if it's JSON
-    else if (isJSON(answer)) {
+    if (isJSON(answer)) {
         displayJSON(answerElement, answer);
     }
     // Otherwise, display as text

--- a/src/main/resources/templates/error.mustache
+++ b/src/main/resources/templates/error.mustache
@@ -1,7 +1,7 @@
 {{> partials/header}}
 {{> partials/nav}}
     <div class="container my-5">
-        <h1>An error has occured</h1>
+        <h1>An error has occurred</h1>
         <i>You probably have a misconfiguration, please check the logs</i>
       </div>
 {{> partials/footer}}

--- a/src/main/resources/templates/partials/footer.mustache
+++ b/src/main/resources/templates/partials/footer.mustache
@@ -8,7 +8,7 @@
       </div>
     </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/src/main/resources/templates/partials/header.mustache
+++ b/src/main/resources/templates/partials/header.mustache
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>LangChain4j demo</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body class="d-flex flex-column min-vh-100">

--- a/src/main/resources/templates/partials/nav.mustache
+++ b/src/main/resources/templates/partials/nav.mustache
@@ -9,10 +9,10 @@
                     <a class="nav-link" href="/">Home page</a>
               </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownBasic" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Basic demos
               </a>
-              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdownBasic">
                   <li><a class="dropdown-item" href="/1">Demo 1: image generation</a></li>
                   <li><a class="dropdown-item" href="/2">Demo 2: simple question</a></li>
                   <li><a class="dropdown-item" href="/3">Demo 3: reasoning</a></li>
@@ -22,10 +22,10 @@
               </ul>
               </li>
               <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownRag" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                       RAG demos
                   </a>
-                  <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownRag">
                       <li><a class="dropdown-item" href="/7">Demo 7: Simple data ingestion</a></li>
                       <li><a class="dropdown-item" href="/8">Demo 8: Querying the vector database</a></li>
                       <li><a class="dropdown-item" href="/9">Demo 9: Advanced data ingestion</a></li>
@@ -33,10 +33,10 @@
                   </ul>
               </li>
               <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownStructured" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                       Structured Outputs demos
                   </a>
-                  <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownStructured">
                       <li><a class="dropdown-item" href="/11">Demo 11: Structured Outputs</a></li>
                       <li><a class="dropdown-item" href="/12">Demo 12: Function calling</a></li>
                       <li><a class="dropdown-item" href="/13">Demo 13: Multiple tools and structured outputs</a></li>
@@ -44,10 +44,10 @@
                   </ul>
               </li>
               <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownAgentic" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                       Agentic demos
                   </a>
-                  <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownAgentic">
                       <li><a class="dropdown-item" href="/15">Demo 15: Agentic AI with 4 agents working together</a></li>
                   </ul>
               </li>


### PR DESCRIPTION
The front-end templates were using Bootstrap 5.3.3 (released early 2024) and had a few correctness issues in the HTML and JavaScript. This PR brings the CDN dependencies up to date and fixes the bugs.

## Changes

- **Bootstrap 5.3.3 -> 5.3.8** -- updated both CSS and JS CDN links in `header.mustache` and `footer.mustache` with current SRI integrity hashes
- **Fixed JS bug in `main.js`** -- `else if` on line 12 had no preceding `if`, which would cause a syntax error at runtime. Changed to `if`.
- **Fixed duplicate HTML IDs in `nav.mustache`** -- all four dropdown toggles shared `id="navbarDropdown"`, which is invalid HTML and can break accessibility tools. Each now has a unique ID (`navbarDropdownBasic`, `navbarDropdownRag`, `navbarDropdownStructured`, `navbarDropdownAgentic`).
- **Fixed typo in `error.mustache`** -- "occured" -> "occurred"