### PR TITLE
Update Maven dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
+		<version>4.0.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -15,8 +15,8 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>25</java.version>
-		<langchain4j.version>1.11.0</langchain4j.version>
-        <elasticsearch.version>9.3.0</elasticsearch.version>
+		<langchain4j.version>1.13.0</langchain4j.version>
+        <elasticsearch.version>9.3.3</elasticsearch.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.3.4</version>
+                <version>1.3.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -112,8 +112,8 @@
         </dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
+            <version>2.0.4</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
All Maven dependencies are bumped to their latest stable releases to pick up bug fixes, security patches, and new features.

### Updated dependencies

| Dependency | Old | New |
|---|---|---|
| Spring Boot | 4.0.3 | 4.0.5 |
| LangChain4j | 1.11.0 | 1.13.0 |
| Elasticsearch (java + rest-client) | 9.3.0 | 9.3.3 |
| Azure SDK BOM | 1.3.4 | 1.3.6 |
| Testcontainers | 1.21.4 | 2.0.4 |

### Notes

- The Testcontainers artifact was renamed from `junit-jupiter` to `testcontainers-junit-jupiter` as part of the 2.0 major release. The Java package names remain unchanged, so no test code changes were needed.
- All versions were verified against Maven Central metadata.
- All 14 tests pass (2 skipped -- the GitHub-dependent tests requiring `GITHUB_TOKEN`).