### PR TITLE
Update GitHub Actions to v5 to fix Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25


### PR DESCRIPTION
GitHub Actions CI was showing "Node.js 20 actions are deprecated" warnings because `actions/checkout@v4` and `actions/setup-java@v4` use the Node.js 20 runtime, which is reaching end-of-life.

Bumps both actions from v4 to v5, which run on Node.js 24 and eliminate the deprecation warnings.