### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -15,8 +15,8 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>25</java.version>
-		<langchain4j.version>1.13.0</langchain4j.version>
-        <elasticsearch.version>9.3.3</elasticsearch.version>
+		<langchain4j.version>1.16.3</langchain4j.version>
+        <elasticsearch.version>9.4.2</elasticsearch.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.3.6</version>
+                <version>1.3.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers-junit-jupiter</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Keeps the demo current with upstream releases of Spring Boot, LangChain4j, and the supporting libraries, picking up bug fixes and security patches without any code changes.

## What changed

All updates are version bumps in `pom.xml`:

| Dependency | Old | New |
|---|---|---|
| spring-boot-starter-parent | 4.0.6 | 4.1.0 |
| langchain4j | 1.13.0 | 1.16.3 |
| elasticsearch | 9.3.3 | 9.4.2 |
| azure-sdk-bom | 1.3.6 | 1.3.7 |
| testcontainers-junit-jupiter | 2.0.4 | 2.0.5 |

The transitive Azure SDK and Logback bumps flow automatically from the upgraded BOMs.

## Verification

Ran `./mvnw -B verify` both before and after the change. Both runs are green: `Tests run: 14, Failures: 0, Errors: 0, Skipped: 2`. The 2 skipped tests are the GitHub-dependent demos (14 and 15), which are correctly disabled because no `GITHUB_TOKEN` was set in this environment. The Spring Boot 4.1.0 repackage step also completed successfully.

No source or application code required changes for these upgrades.