### PR TITLE
Add BootUI dev console via dev-only Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,17 @@
                 <junit.jupiter.tags.include>github-dependent</junit.jupiter.tags.include>
             </properties>
         </profile>
+		<profile>
+			<!-- Dev-only profile: enables the BootUI local developer console. Activate with -Pdev. -->
+			<id>dev</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.julien-dubois.bootui</groupId>
+					<artifactId>bootui-spring-boot-starter</artifactId>
+					<version>1.5.2</version>
+				</dependency>
+			</dependencies>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
## Why

Local development benefits from BootUI's developer console for inspecting and interacting with the running Spring Boot app, but that tooling has no place in production builds. This wires it up so it's available on demand without affecting normal builds.

## What

Adds a `dev` Maven profile to `pom.xml` that depends on `com.julien-dubois.bootui:bootui-spring-boot-starter`, pinned to `1.5.2` (latest release on Maven Central, concrete version rather than a range).

The profile is **inactive by default**, so `./mvnw verify`, `./mvnw spring-boot:run`, and the native build are completely unaffected. BootUI is only pulled onto the classpath when building or running with `-Pdev`.

## How to use

```bash
./mvnw -Pdev spring-boot:run -Dspring-boot.run.profiles=dev
```

Then open http://localhost:8080/bootui

## Validation

- With `-Pdev`: `dependency:list` shows `bootui-spring-boot-starter:1.5.2` on the classpath, build succeeds.
- Without `-Pdev`: zero references to BootUI, confirming production builds are unchanged.